### PR TITLE
fix sample IQN formatting

### DIFF
--- a/invalid/config1
+++ b/invalid/config1
@@ -2,11 +2,11 @@
     "_target": [
       {
         "host": "igw1",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "_auth": [

--- a/invalid/config2
+++ b/invalid/config2
@@ -2,11 +2,11 @@
     "_target": [
       {
         "host": "igw1",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "_auth": [

--- a/invalid/config3
+++ b/invalid/config3
@@ -2,11 +2,11 @@
     "_target": [
       {
         "host": "igw1",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "_auth": [

--- a/invalid/config4
+++ b/invalid/config4
@@ -2,11 +2,11 @@
     "_target": [
       {
         "host": "igw1",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "_auth": [

--- a/invalid/config5
+++ b/invalid/config5
@@ -2,11 +2,11 @@
     "_target": [
       {
         "host": "igw1",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "iqn": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "iqn": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "_auth": [

--- a/invalid/runtime1
+++ b/invalid/runtime1
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/invalid/runtime2
+++ b/invalid/runtime2
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/2gateways+2images+2targets+no_authentication.json
+++ b/samples/2gateways+2images+2targets+no_authentication.json
@@ -2,10 +2,10 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     },
     {
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.second",
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.second",
       "authentication": "tpg",
       "tpg": {
           "userid": "common2",
@@ -19,14 +19,14 @@
           { "host": "igw1", "portal": "portal1" },
           { "host": "igw2", "portal": "portal2" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     },
     {
       "hosts": [
           { "host": "igw1", "portal": "portal3" },
           { "host": "igw2", "portal": "portal4" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.second"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.second"
     }
   ], 
   "portals": [
@@ -52,7 +52,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"
@@ -63,7 +63,7 @@
           ] 
         }, 
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.second",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.second",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+2images+assigned_lun+no_authentication.json
+++ b/samples/2gateways+2images+assigned_lun+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -11,7 +11,7 @@
           { "host": "igw1", "portal": "portal1" },
           { "host": "igw2", "portal": "portal2" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -29,7 +29,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city",

--- a/samples/2gateways+2images+no_authentication.json
+++ b/samples/2gateways+2images+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -11,7 +11,7 @@
           { "host": "igw1", "portal": "portal1" },
           { "host": "igw2", "portal": "portal2" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -29,7 +29,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+2portals+2images+isolated+no_authentication.json
+++ b/samples/2gateways+2portals+2images+isolated+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -13,7 +13,7 @@
           { "host": "igw2", "portal": "portal3" },
           { "host": "igw2", "portal": "portal4" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -39,7 +39,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+2portals+2images+no_authentication.json
+++ b/samples/2gateways+2portals+2images+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -11,7 +11,7 @@
           { "host": "igw1", "portal": "portal3" },
           { "host": "igw2", "portal": "portal4" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -29,7 +29,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+2portals+no_authentication.json
+++ b/samples/2gateways+2portals+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -11,7 +11,7 @@
           { "host": "igw1", "portal": "portal3" },
           { "host": "igw2", "portal": "portal4" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -29,7 +29,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+no_authentication.json
+++ b/samples/2gateways+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -11,7 +11,7 @@
           { "host": "igw1", "portal": "portal1" },
           { "host": "igw2", "portal": "portal2" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -29,7 +29,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/2gateways+tpg+identified.json
+++ b/samples/2gateways+tpg+identified.json
@@ -1,7 +1,7 @@
 {
   "auth": [
     {
-        "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+        "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
         "authentication": "tpg+identified",
         "tpg": {
             "userid": "common2",
@@ -15,7 +15,7 @@
           { "host": "igw1", "portal": "portal1" },
           { "host": "igw2", "portal": "portal2" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -33,7 +33,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city", 

--- a/samples/2plain+3gateways+2portals+2images+isolated+no_authentication.json
+++ b/samples/2plain+3gateways+2portals+2images+isolated+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     },
     {
       "authentication": "none", 
@@ -16,11 +16,11 @@
   "targets": [
     {
       "host": "igw1",
-      "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+      "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
     },
     {
       "host": "igw2",
-      "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.lmnopqrstuv"
+      "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.lmnopqrstuv"
     },
     {
       "hosts": [
@@ -31,7 +31,7 @@
           { "host": "igw3", "portal": "portal5" },
           { "host": "igw3", "portal": "portal6" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -87,7 +87,7 @@
           ]
         },
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/3gateways+2portals+2images+isolated+no_authentication.json
+++ b/samples/3gateways+2portals+2images+isolated+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -15,7 +15,7 @@
           { "host": "igw3", "portal": "portal5" },
           { "host": "igw3", "portal": "portal6" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -49,7 +49,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/3gateways+no_authentication.json
+++ b/samples/3gateways+no_authentication.json
@@ -2,7 +2,7 @@
   "auth": [
     {
       "authentication": "none", 
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "targets": [
@@ -12,7 +12,7 @@
           { "host": "igw2", "portal": "portal2" },
           { "host": "igw3", "portal": "portal3" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -34,7 +34,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city"

--- a/samples/3gateways+tpg+identified.json
+++ b/samples/3gateways+tpg+identified.json
@@ -1,7 +1,7 @@
 {
   "auth": [
     {
-        "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+        "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
         "authentication": "tpg+identified",
         "tpg": {
             "userid": "common2",
@@ -16,7 +16,7 @@
           { "host": "igw2", "portal": "portal2" },
           { "host": "igw3", "portal": "portal3" }
       ],
-      "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+      "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
     }
   ], 
   "portals": [
@@ -38,7 +38,7 @@
       "pool": "rbd",
       "gateways": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "image": "city", 

--- a/samples/acls+discovery+mutual.json
+++ b/samples/acls+discovery+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/acls+discovery.json
+++ b/samples/acls+discovery.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/acls+mutual+discovery+mutual.json
+++ b/samples/acls+mutual+discovery+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/acls+mutual+discovery.json
+++ b/samples/acls+mutual+discovery.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/acls+mutual.json
+++ b/samples/acls+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/acls.json
+++ b/samples/acls.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/complete.json
+++ b/samples/complete.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/no_authentication+explicit.json
+++ b/samples/no_authentication+explicit.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/no_authentication.json
+++ b/samples/no_authentication.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "portals": [

--- a/samples/nonstandard_port+no_authentication.json
+++ b/samples/nonstandard_port+no_authentication.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       }
     ],
     "auth": [

--- a/samples/plain+2gateways+2portals+2images+isolated+combined.json
+++ b/samples/plain+2gateways+2portals+2images+isolated+combined.json
@@ -1,7 +1,7 @@
 {
   "auth": [
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "authentication": "acls", 
           "acls": [ 
             {
@@ -12,7 +12,7 @@
           ]
         },
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant-too",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant-too",
           "authentication": "acls", 
           "acls": [ 
             {
@@ -37,18 +37,18 @@
             { "host": "igw1", "portal": "portal1" },
             { "host": "igw2", "portal": "portal2" }
         ],
-        "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant"
+        "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant"
       },
       {
         "hosts": [
             { "host": "igw1", "portal": "portal3" },
             { "host": "igw2", "portal": "portal4" }
         ],
-        "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant-too"
+        "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant-too"
       },
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
   ], 
   "portals": [
@@ -83,7 +83,7 @@
           ]
         }, 
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant",
           "tpg": [
             {
               "initiator": "iqn.1996-04.de.suse:01:e6ca28cc9f20",
@@ -92,7 +92,7 @@
           ] 
         }, 
         {
-          "target": "iqn.2003-01.org.linux-iscsi.igw.x86:sn.redundant-too",
+          "target": "iqn.2003-01.org.linux-iscsi:igw.x86:sn.redundant-too",
           "tpg": [
             {
               "initiator": "iqn.1996-04.de.suse:01:e6ca28cc9f24",

--- a/samples/plain+attributes.json
+++ b/samples/plain+attributes.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk",
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk",
         "tpg_login_timeout": "10",
         "tpg_default_cmdsn_depth": "64",
         "tpg_default_erl": "0",

--- a/samples/plain+rbd_name.json
+++ b/samples/plain+rbd_name.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/samples/plain+retries.json
+++ b/samples/plain+retries.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/samples/plain+uuid.json
+++ b/samples/plain+uuid.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/samples/plain+wwn_generate.json
+++ b/samples/plain+wwn_generate.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk",
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk",
         "wwn_generate": "original"
       }
     ],

--- a/samples/plain.json
+++ b/samples/plain.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/samples/simple.json
+++ b/samples/simple.json
@@ -2,7 +2,7 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.generic.x86:sn.abcdefghijk"
+        "target": "iqn.2003-01.org.linux-iscsi:generic.x86:sn.abcdefghijk"
       }
     ],
     "auth": [

--- a/samples/tpg+discovery+mutual.json
+++ b/samples/tpg+discovery+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+discovery.json
+++ b/samples/tpg+discovery.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+identified+mutual+discovery+mutual.json
+++ b/samples/tpg+identified+mutual+discovery+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+identified.json
+++ b/samples/tpg+identified.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+mutual+discovery+mutual.json
+++ b/samples/tpg+mutual+discovery+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+mutual+discovery.json
+++ b/samples/tpg+mutual+discovery.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg+mutual.json
+++ b/samples/tpg+mutual.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [

--- a/samples/tpg.json
+++ b/samples/tpg.json
@@ -2,11 +2,11 @@
     "targets": [
       {
         "host": "igw1",
-        "target": "iqn.2003-01.org.linux-iscsi.igw1.x86:sn.1a2b6ae09141"
+        "target": "iqn.2003-01.org.linux-iscsi:igw1.x86:sn.1a2b6ae09141"
       },
       {
         "host": "igw2",
-        "target": "iqn.2003-01.org.linux-iscsi.igw2.x86:sn.b611a553e579"
+        "target": "iqn.2003-01.org.linux-iscsi:igw2.x86:sn.b611a553e579"
       }
     ],
     "auth": [


### PR DESCRIPTION
The lrbd sample configurations frequently use IQNs with a reversed
domain name component (see below) of "org.linux-iscsi.$HOST.$ARCH". Fix
this to use "org.linux-iscsi" instead, and place the $HOST.$ARCH
string after a ':' separator.

rfc3720 specifies:

  The iSCSI qualified name string consists of:

      -  The string "iqn." ...
      -  A date code, in yyyy-mm format. ...
      -  A dot "."
      -  The reversed domain name of the naming authority (person or
         organization) creating this iSCSI name.
      -  An optional, colon (:) prefixed, string within the character
         set and length boundaries that the owner of the domain name
         deems appropriate.  This may contain product types, serial
         numbers, host identifiers, or software keys (e.g., it may
         include colons to separate organization boundaries).  With the
         exception of the colon prefix, the owner of the domain name can
         assign everything after the reversed domain name as desired.
         It is the responsibility of the entity that is the naming
         authority to ensure that the iSCSI names it assigns are
         worldwide unique.  For example, "Example Storage Arrays, Inc.",
         might own the domain name "example.com".

Signed-off-by: David Disseldorp <ddiss@suse.de>